### PR TITLE
Add functionality for user to specify output filename and overwrite input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ Options:
   -V, --version  Print version
 ```
 
-support signal type:
-- sine
-- white noise
-
 ### generate wav files
 
 - support waveform

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -35,7 +35,7 @@ pub struct TaperSpecOptions {
     )]
     pub length_of_taper: usize,
 
-    // type of taper
+    /// type of taper
     #[arg(
         short, long,
         default_value = "linear",

--- a/src/commands/taper.rs
+++ b/src/commands/taper.rs
@@ -2,8 +2,8 @@ use clap::Args;
 
 #[derive(Args, Debug)]
 pub struct TaperOptions {
-    /// the input filename
-    pub filename: String,
+    /// input filename
+    pub input: String,
 
     #[command(flatten)]
     pub taper_opt: super::common::TaperSpecOptions,

--- a/src/commands/taper.rs
+++ b/src/commands/taper.rs
@@ -5,6 +5,11 @@ pub struct TaperOptions {
     /// input filename
     pub input: String,
 
+    ///  Output filename.
+    /// If specified without an argument, input file will be overridden.
+    #[arg(short, long)]
+    pub output: Option<Option<String>>,
+
     #[command(flatten)]
     pub taper_opt: super::common::TaperSpecOptions,
 }

--- a/src/fileio.rs
+++ b/src/fileio.rs
@@ -13,7 +13,7 @@ pub struct FileInfo {
 fn is_file_exist(filename: &str) -> bool {
     let exists = Path::new(filename).exists();
     if exists{
-        println!("The file [{}] already exists", filename);
+        println!("The file [{}] already exists.", filename);
     }
     exists
 }
@@ -78,10 +78,9 @@ pub fn gen_file_name(sig_type: &str, start_freq: i32, end_freq: i32, filename_ch
     );
 
     let mut override_msg = String::new();
-    if Path::new(&filename).exists() {
-        println!("ファイルがすでに存在します。というメッセージだしたい");
+    if is_file_exist(&filename) {
         file_override_check(&filename)?;
-        override_msg = " (file override)".to_string();
+        override_msg = "(file override)".to_string();
     }
 
     Ok(FileInfo {
@@ -90,13 +89,18 @@ pub fn gen_file_name(sig_type: &str, start_freq: i32, end_freq: i32, filename_ch
     })
 }
 
-pub fn set_output_filename(output_filename: Option<Option<String>>, input_filename: &str) -> Result<String, Box<dyn Error>> {
+pub fn set_output_filename(output_filename: Option<Option<String>>, input_filename: &str) -> Result<FileInfo, Box<dyn Error>> {
+    let mut override_msg = "";
     match output_filename {
-        Some(Some(ref name)) if !name.is_empty() => {
+        Some(Some(ref name)) if !name.is_empty() => { // @todo .wavの拡張子がついているかチェックを追加する
             if is_file_exist(name) {
                 file_override_check(name)?;
+                override_msg = "(file override)";
             }
-            Ok(name.clone()) // @todo .wavの拡張子がついているかチェックを追加する
+            Ok(FileInfo {
+                    name: name.clone(),
+                    exists_msg: override_msg.to_string(),
+            })
         }
         Some(Some(_)) => {
             return Err("The output filename is empty!".into());
@@ -104,15 +108,23 @@ pub fn set_output_filename(output_filename: Option<Option<String>>, input_filena
         Some(None) => {
             if is_file_exist(input_filename) {
                 file_override_check(input_filename)?;
+                override_msg = " (file override)";
             }
-            Ok(input_filename.to_string())
+            Ok(FileInfo {
+                name: input_filename.to_string(),
+                exists_msg: override_msg.to_string(),
+            })
         }
         None => {
             let default_name = format!("{}_tapered.wav", extract_stem(input_filename));
             if is_file_exist(&default_name) {
                 file_override_check(&default_name)?;
+                override_msg = " (file override)";
             }
-            Ok(default_name)
+            Ok(FileInfo {
+                name: default_name,
+                exists_msg: override_msg.to_string(),
+            })
         }
     }
 }

--- a/src/fileio.rs
+++ b/src/fileio.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 use std::io::{self, Write};
-use std::process::exit;
+use std::error::Error;
 
 pub mod wavread;
 pub mod wavwrite;
@@ -10,31 +10,22 @@ pub struct FileInfo {
     pub exists_msg: String,
 }
 
-fn file_exists_errorcheck(filename: &String) -> String {
-    let mut override_msg = String::new();
-    if Path::new(&filename).exists() {
-        print!("file \"{}\" is already exists, override? [y/N] ", filename);
-
-        let mut input = String::new();
-        io::stdout().flush().unwrap();
-        if io::stdin().read_line(&mut input).is_err() {
-            eprintln!("Error: reading input. Exiting...");
-            exit(1);
-        }
-
-        match input.trim().to_lowercase().as_str() {
-            "n" | "no" | "" => {
-                eprintln!("Abort! The operation was canceled by the user.");
-                eprintln!("No output was generated.");
-                exit(1);
-            }
-            _ => {
-                override_msg = " (file override)".to_string();
-            }
-        }
+fn file_override_check(filename: &str) -> Result<(), Box<dyn Error>> {
+    let mut input = String::new();
+    print!("The file [{}] will be overridden. Are you sure? [y/N] ", filename);
+    io::stdout().flush().unwrap();
+    if io::stdin().read_line(&mut input).is_err() {
+        return Err("failed to reading input".into());
     }
 
-    override_msg
+    match input.trim().to_lowercase().as_str() {
+        "y" | "yes" => {
+            Ok(())
+        }
+        _=> {
+            return Err("The operation was canceled by user.".into());
+        }
+    }
 }
 
 fn freq_format(freq: i32, prefix: &str) -> String {
@@ -61,7 +52,14 @@ fn seconds_format(sec: u32) -> String{
     }
 }
 
-pub fn gen_file_name(sig_type: &str, start_freq: i32, end_freq: i32, filename_ch: &str, d: u32) -> FileInfo {
+fn extract_stem(input_filename: &str) -> String {
+    Path::new(input_filename)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("").to_string()
+}
+
+pub fn gen_file_name(sig_type: &str, start_freq: i32, end_freq: i32, filename_ch: &str, d: u32) -> Result<FileInfo, Box<dyn Error>> {
     let filename_start_freq = freq_format(start_freq, "");
     let filename_end_freq = freq_format(end_freq, "to_");
     let filename_duration = seconds_format(d);
@@ -71,21 +69,34 @@ pub fn gen_file_name(sig_type: &str, start_freq: i32, end_freq: i32, filename_ch
         sig_type, filename_start_freq, filename_end_freq, filename_duration, filename_ch
     );
 
-    let override_msg = file_exists_errorcheck(&filename);
+    let mut override_msg = String::new();
+    if Path::new(&filename).exists() {
+        file_override_check(&filename)?;
+        override_msg = " (file override)".to_string();
+    }
 
-    FileInfo {
+    Ok(FileInfo {
         name: filename,
         exists_msg: override_msg,
-    }
+    })
 }
 
-pub fn set_output_filename(input_filename: &str) -> String {
-    let stem = Path::new(input_filename)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("");
-
-    let output_filename = format!("{}_tapered.wav", stem);
-    
-    output_filename
+pub fn set_output_filename(output_filename: Option<Option<String>>, input_filename: &str) -> Result<String, Box<dyn Error>> {
+    match output_filename {
+        Some(Some(ref name)) if !name.is_empty() => {
+            println!("user specified output filename will use!");
+            Ok(name.clone()) // @todo .wavの拡張子がついているかチェックを追加する
+        }
+        Some(Some(_)) => {
+            return Err("The output filename is empty!".into());
+        }
+        Some(None) => {
+            file_override_check(input_filename)?;
+            Ok(input_filename.to_string())
+        }
+        None => {
+            println!("default filename will use");
+            Ok(format!("{}_tapered.wav", extract_stem(input_filename)).to_string())
+        }
+    }
 }

--- a/src/fileio.rs
+++ b/src/fileio.rs
@@ -10,6 +10,13 @@ pub struct FileInfo {
     pub exists_msg: String,
 }
 
+fn is_wav_file(filename: &str) -> bool {
+    Path::new(filename)
+        .extension()
+        .map(|e| e == "wav")
+        .unwrap_or(false)
+}
+
 fn is_file_exist(filename: &str) -> bool {
     let exists = Path::new(filename).exists();
     if exists{

--- a/src/fileio.rs
+++ b/src/fileio.rs
@@ -10,6 +10,14 @@ pub struct FileInfo {
     pub exists_msg: String,
 }
 
+fn is_file_exist(filename: &str) -> bool {
+    let exists = Path::new(filename).exists();
+    if exists{
+        println!("The file [{}] already exists", filename);
+    }
+    exists
+}
+
 fn file_override_check(filename: &str) -> Result<(), Box<dyn Error>> {
     let mut input = String::new();
     print!("The file [{}] will be overridden. Are you sure? [y/N] ", filename);
@@ -71,6 +79,7 @@ pub fn gen_file_name(sig_type: &str, start_freq: i32, end_freq: i32, filename_ch
 
     let mut override_msg = String::new();
     if Path::new(&filename).exists() {
+        println!("ファイルがすでに存在します。というメッセージだしたい");
         file_override_check(&filename)?;
         override_msg = " (file override)".to_string();
     }
@@ -84,19 +93,26 @@ pub fn gen_file_name(sig_type: &str, start_freq: i32, end_freq: i32, filename_ch
 pub fn set_output_filename(output_filename: Option<Option<String>>, input_filename: &str) -> Result<String, Box<dyn Error>> {
     match output_filename {
         Some(Some(ref name)) if !name.is_empty() => {
-            println!("user specified output filename will use!");
+            if is_file_exist(name) {
+                file_override_check(name)?;
+            }
             Ok(name.clone()) // @todo .wavの拡張子がついているかチェックを追加する
         }
         Some(Some(_)) => {
             return Err("The output filename is empty!".into());
         }
         Some(None) => {
-            file_override_check(input_filename)?;
+            if is_file_exist(input_filename) {
+                file_override_check(input_filename)?;
+            }
             Ok(input_filename.to_string())
         }
         None => {
-            println!("default filename will use");
-            Ok(format!("{}_tapered.wav", extract_stem(input_filename)).to_string())
+            let default_name = format!("{}_tapered.wav", extract_stem(input_filename));
+            if is_file_exist(&default_name) {
+                file_override_check(&default_name)?;
+            }
+            Ok(default_name)
         }
     }
 }

--- a/src/fileio/wavread.rs
+++ b/src/fileio/wavread.rs
@@ -1,8 +1,15 @@
-use hound::{WavReader, WavSpec, Error};
+use std::error::Error;
+use hound::{WavReader, WavSpec};
 
-pub fn read_wav_file(filename: &str) -> Result<(Vec<Vec<f64>>, WavSpec), Error> {
-    let mut reader = WavReader::open(filename)?;
-    let spec = reader.spec();
+use super::is_wav_file;
+
+pub fn read_wav_file(filename: &str) -> Result<(Vec<Vec<f64>>, WavSpec), Box<dyn Error>> {
+    if !is_wav_file(filename) {
+        return Err("the filename must have a .wav extension".into());
+    }
+
+    let mut reader =  WavReader::open(filename)?;
+    let spec = reader.spec().clone();
     let num_channels = spec.channels as usize;
     let mut samples = vec![Vec::new(); num_channels];
 

--- a/src/fileio/wavwrite.rs
+++ b/src/fileio/wavwrite.rs
@@ -1,5 +1,7 @@
-use hound::{WavSpec, WavWriter};
 use std::error::Error;
+use hound::{WavSpec, WavWriter};
+
+use super::is_wav_file;
 
 pub fn write_wav_file(
     spec: WavSpec,
@@ -8,6 +10,10 @@ pub fn write_wav_file(
     enable_l: bool,
     enable_r: bool,
 ) -> Result<(), Box<dyn Error>> {
+    if !is_wav_file(filename) {
+        return Err("The filename must have a .wav extension".into());
+    }
+
     let mut writer = WavWriter::create(filename, spec)?;
 
     let total_samples = samples[0].len();

--- a/src/fileio/wavwrite.rs
+++ b/src/fileio/wavwrite.rs
@@ -1,4 +1,5 @@
 use hound::{WavSpec, WavWriter};
+use std::error::Error;
 
 pub fn write_wav_file(
     spec: WavSpec,
@@ -6,7 +7,7 @@ pub fn write_wav_file(
     samples: &[Vec<f64>],
     enable_l: bool,
     enable_r: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn Error>> {
     let mut writer = WavWriter::create(filename, spec)?;
 
     let total_samples = samples[0].len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     if let commands::Commands::Taper(taper_options) = &args.subcommand {
-        processing::apply_taper_to_wav(&taper_options, &taper_spec)?;
+        let fileinfo = processing::apply_taper_to_wav(&taper_options, &taper_spec)?;
+        println!("WAV file [{}] created successfully {}", fileinfo.name, fileinfo.exists_msg);
         return Ok(());
     }
 
@@ -119,7 +120,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     fileio::wavwrite::write_wav_file(wav_spec, &fileinfo.name, &samples_to_write, enable_l, enable_r)?;
 
-    println!("WAV file \"{}\" created successfully{}", fileinfo.name, fileinfo.exists_msg);
+    println!("WAV file [{}] created successfully {}", fileinfo.name, fileinfo.exists_msg);
 
     Ok(())
 }

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -2,18 +2,18 @@ use std::f32::consts::PI;
 use std::process::exit;
 use std::error::Error;
 use rtaper::TaperSpec;
+use crate::commands::taper::TaperOptions;
 use crate::SignalSpec;
 use crate::fileio::{wavwrite, wavread};
 
-pub fn apply_taper_to_wav(filename: &str, taper_spec: &TaperSpec) -> Result<(), Box<dyn Error>> {
-    let (mut samples, spec) = wavread::read_wav_file(filename)?;
-
+pub fn apply_taper_to_wav(options: &TaperOptions, taper_spec: &TaperSpec) -> Result<(), Box<dyn Error>> {
+    let (mut samples, spec) = wavread::read_wav_file(options.input.as_str())?;
     let num_ch = samples.len();
     for i in 0..num_ch {
-        rtaper::apply_taper_both(&mut samples[i], taper_spec)?;
+        rtaper::apply_taper_both(&mut samples[i], &taper_spec)?;
     }
 
-    let output_filename = crate::fileio::set_output_filename(filename);
+    let output_filename = crate::fileio::set_output_filename(options.output.clone(), options.input.as_str())?;
     wavwrite::write_wav_file(spec, output_filename.as_str(), &samples, true, true)?;
 
     Ok(())

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -4,19 +4,19 @@ use std::error::Error;
 use rtaper::TaperSpec;
 use crate::commands::taper::TaperOptions;
 use crate::SignalSpec;
-use crate::fileio::{wavwrite, wavread};
+use crate::fileio::{wavread, wavwrite, FileInfo};
 
-pub fn apply_taper_to_wav(options: &TaperOptions, taper_spec: &TaperSpec) -> Result<(), Box<dyn Error>> {
+pub fn apply_taper_to_wav(options: &TaperOptions, taper_spec: &TaperSpec) -> Result<FileInfo, Box<dyn Error>> {
     let (mut samples, spec) = wavread::read_wav_file(options.input.as_str())?;
     let num_ch = samples.len();
     for i in 0..num_ch {
         rtaper::apply_taper_both(&mut samples[i], &taper_spec)?;
     }
 
-    let output_filename = crate::fileio::set_output_filename(options.output.clone(), options.input.as_str())?;
-    wavwrite::write_wav_file(spec, output_filename.as_str(), &samples, true, true)?;
+    let fileinfo = crate::fileio::set_output_filename(options.output.clone(), options.input.as_str())?;
+    wavwrite::write_wav_file(spec, fileinfo.name.as_str(), &samples, true, true)?;
 
-    Ok(())
+    Ok(fileinfo)
 }
 
 pub fn generate_sine_wave(spec: &SignalSpec, frequency: u32) -> Vec<f64> {


### PR DESCRIPTION
-o --outputオプションを活用

- `-o`オプションが未指定の場合
```bash
./sigen taper input.wav # defaultのファイル名: <input>_tapered.wavで出力
```

- `-o`オプションを引数無しで指定した場合
```bash
./sigen taper input.wav -o # input.wavが上書きされる
```

- `-o`オプションを引数付きで指定した場合
```bash
./sigen taper input.wav -o output.wav # output.wavで出力
```